### PR TITLE
Add config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+config.yml

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ hf
 
 ## Setup 
 
- 1. Download the python script and config.yml from Github
- 2. Install the Meshtastic python CLI https://meshtastic.org/docs/software/python/cli/installation/
- 3. Install discord py https://discordpy.readthedocs.io/en/latest/intro.html
- 4. Create a discord bot https://discord.com/developers
- 5. Give it admin permission in your server and give it read messages intent (google it if you don't know what to do)
- 6. Invite it to a server
- 7. Get the discord channel id (this is where the messages will go) (again google a tutorial if don't know how to get the channel id)
- 8. Get the discord bot token
- 9. Edit the python file to configure the settings
- 10. Put in the discord bot token and channel id
+ 1. Download the python script and config-example.yml from Github
+ 2. Rename config-example.yml to config.yml before editing (step 10)
+ 3. Install the Meshtastic python CLI https://meshtastic.org/docs/software/python/cli/installation/
+ 4. Install discord py https://discordpy.readthedocs.io/en/latest/intro.html
+ 5. Create a discord bot https://discord.com/developers
+ 6. Give it admin permission in your server and give it read messages intent (google it if you don't know what to do)
+ 7. Invite it to a server
+ 8. Get the discord channel id (this is where the messages will go) (again google a tutorial if don't know how to get the channel id)
+ 9. Get the discord bot token
+ 10. Add your discord bot token and channel id(s) to config.yml
  11. If you are using serial set `use_serial` to `True` otherwise get your nodes ip and put it into the `radio_ip` setting
  12. Run the script
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -1,0 +1,17 @@
+max_message_length: 170 # max discord -> mesh message length
+info_channel_ids: [ 123456789012345 ] # seperate more by commas
+message_channel_ids: [ 123456789012345 ] # can be the same as info_channel_ids
+token: "asdfasdfasdfasdf" # discord bot token - DO NOT SHARE
+prefix: "$" # mesh command prefix
+discord_prefix: "$" # discord prefix
+use_serial: True
+radio_ip: "192.168.1.169"
+send_channel_index: 0
+ignore_self: True # dont show your own node in the mesh
+send_packets: True # show all data not just messages
+verbose_packets: True # should the full packet data be shown in the console
+weather_lat: "45.51"
+weather_long: "-122.68"
+max_weather_hours: 4 # how many hours ahead to send weather info for
+ping_on_messages: False
+message_role: "@here"


### PR DESCRIPTION
This PR moves the active config file to gitignore so it is not not overwritten when updated from the latest github master.  On a fresh install, the user will need to rename config-example.yml to config.yml.